### PR TITLE
Fix IDs being null

### DIFF
--- a/src/main/java/net/oijon/oling/datatypes/language/Language.java
+++ b/src/main/java/net/oijon/oling/datatypes/language/Language.java
@@ -295,6 +295,11 @@ public class Language implements XMLDatatype {
                     switch (nl.item(i).getNodeName()) {
                         case "meta":
                             properties = new LanguageProperties(element);
+                            if (!properties.checkID()) {
+                            	log.warn("This language appears to have a blank or null ID!");
+                            	log.warn("Generating new ID, this may break relations with other languages!");
+                            	properties.generateID();
+                            }
                             break;
                         case "phonology":
                             phono = new Phonology(element);

--- a/src/main/java/net/oijon/oling/datatypes/language/LanguageProperties.java
+++ b/src/main/java/net/oijon/oling/datatypes/language/LanguageProperties.java
@@ -63,7 +63,7 @@ public class LanguageProperties implements XMLDatatype {
 		
 		Multitag meta = docTag.getMultitag("Meta");
 		lp.setProperty(LanguageProperty.NAME, meta.getDirectChild("name").value());
-		lp.checkID(meta);
+		lp.checkLegacyID(meta);
 		lp.setProperty(LanguageProperty.AUTONYM, meta.getDirectChild("autonym").value());
 		lp.setReadOnly(Boolean.parseBoolean(meta.getDirectChild("readonly").value()));
 		lp.setCreated(new Date(Long.parseLong(meta.getDirectChild("timeCreated").value())));
@@ -76,7 +76,7 @@ public class LanguageProperties implements XMLDatatype {
 	/**
 	 * Generates an ID for the language
 	 */
-	private void generateID() {
+	public void generateID() {
 		int rand = (int) (Math.random() * 100000);
 		// "its deprecated" i dont care
 		// why does DateTimeFormatter not accept date objects :(
@@ -91,13 +91,21 @@ public class LanguageProperties implements XMLDatatype {
 				+ rand);
 	}
 	
+	public boolean checkID() {
+		String id = this.getProperty(LanguageProperty.ID);
+		if (id != null && !id.isBlank() && !id.equals("null")) {
+			return true;
+		}
+		return false;
+	}
+	
 	/**
 	 * Checks if the ID tag is using an old, unsupported version. Useful for backwards-compatibility.
 	 * @deprecated as of OLing v3.0.0, as this uses the old file format.
 	 * @param meta
 	 */
 	@Deprecated
-	private void checkID(Multitag meta) {
+	private void checkLegacyID(Multitag meta) {
 		Tag id = new Tag("id");
 		try {
 			id = meta.getDirectChild("id");

--- a/src/test/java/oling/UnitTests.java
+++ b/src/test/java/oling/UnitTests.java
@@ -1,6 +1,7 @@
 package oling;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -10,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import net.oijon.oling.datatypes.language.LanguageProperties;
+import net.oijon.oling.datatypes.language.LanguageProperty;
 import net.oijon.oling.datatypes.phonology.*;
 import net.oijon.oling.datatypes.phonology.feature.Feature;
 import net.oijon.oling.datatypes.phonology.feature.sonorancy.SonorancyTree;
@@ -353,4 +355,27 @@ public class UnitTests {
 		log.info("Diacritic equivalency successfully verified!");
 	}
 	
+	@Test
+	void testBrokenID() {
+		log.info("Testing broken ID repair");
+		try {
+			File f = Paths.get(UnitTests.class.getClassLoader().getResource("testish.xml").toURI()).toFile();
+			Language l = Language.parse(f);
+			
+			l.getProperties().setProperty(LanguageProperty.ID, "null");
+			
+			File temp = File.createTempFile("testlang", "xml");
+            l.toFile(temp);
+			
+            Language newLang = Language.parse(temp);
+            
+            assertNotEquals(newLang.getProperties().getProperty(LanguageProperty.ID), "null");
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+			log.err("Could not load needed resources!");
+			fail();
+		}
+		log.info("Broken ID repair successfully verified!");
+	}
 }


### PR DESCRIPTION
The legacy parser originally checked for broken IDs. This was not converted to XML. Now it has!